### PR TITLE
ci: grant write permissions for flake.lock update action

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -5,13 +5,16 @@ on:
 jobs:
   update-flake-inputs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: DeterminateSystems/determinate-nix-action@v3
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@main
         with:
-          pr-title: "Update flake.lock" # Title of PR to be created
-          pr-labels: | # Labels to be set on the PR
+          pr-title: "Update flake.lock"
+          pr-labels: |
             dependencies
             automated


### PR DESCRIPTION
The GITHUB_TOKEN defaults to read-only for schedule-triggered workflows, causing the update-flake-lock action to fail with a 403 when pushing the update branch.

Add explicit contents: write and pull-requests: write permissions so the action can push the branch and create the PR.