### PR TITLE
ci: use PAT for flake lock PR to trigger CI automatically

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,15 +29,15 @@ jobs:
 
   flake-lock:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'github-actions[bot]' && github.event.pull_request.title == 'Update flake.lock' && github.repository == 'zahidkizmaz/edi-format'
+    if: github.event.pull_request.user.login == 'zahidkizmaz' && github.event.pull_request.title == 'Update flake.lock' && github.repository == 'zahidkizmaz/edi-format'
     steps:
       - name: Approve flake lock update PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.PR_AUTO_APPROVE_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for flake lock update
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.PR_AUTO_APPROVE_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@main
         with:
+          token: ${{ secrets.PR_AUTO_APPROVE_PAT }}
           pr-title: "Update flake.lock"
           branch: ${{ env.BRANCH_NAME }}
           pr-labels: |


### PR DESCRIPTION
Pass PR_AUTO_APPROVE_PAT to the update-flake-lock action so the PR is authored as a real user (zahidkizmaz), letting CI run without manual approval. The auto-approve job uses GITHUB_TOKEN since it is now a different actor from the PR author.