### PR TITLE
chore: add 14-day cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,13 @@ updates:
     open-pull-requests-limit: 20
     allow:
       - dependency-type: "all"
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
Dependabot will now wait 14 days before creating a new version update PR for the same dependency, reducing PR churn.